### PR TITLE
02_graphql_setup

### DIFF
--- a/api/Gemfile
+++ b/api/Gemfile
@@ -45,3 +45,4 @@ gem 'pry-rails'
 
 gem 'devise'
 gem 'devise_token_auth' 
+gem 'graphql' 

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    graphql (2.0.11)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     listen (3.7.1)
@@ -178,6 +179,7 @@ DEPENDENCIES
   byebug
   devise
   devise_token_auth
+  graphql
   listen (~> 3.2)
   pry-rails
   puma (~> 4.1)

--- a/api/app/controllers/graphql_controller.rb
+++ b/api/app/controllers/graphql_controller.rb
@@ -1,0 +1,50 @@
+class GraphqlController < ApplicationController
+  # If accessing from outside this domain, nullify the session
+  # This allows for outside API access while preventing CSRF attacks,
+  # but you'll have to authenticate your user separately
+  # protect_from_forgery with: :null_session
+
+  def execute
+    variables = prepare_variables(params[:variables])
+    query = params[:query]
+    operation_name = params[:operationName]
+    context = {
+      # Query context goes here, for example:
+      # current_user: current_user,
+    }
+    result = ApiSchema.execute(query, variables: variables, context: context, operation_name: operation_name)
+    render json: result
+  rescue StandardError => e
+    raise e unless Rails.env.development?
+    handle_error_in_development(e)
+  end
+
+  private
+
+  # Handle variables in form data, JSON body, or a blank value
+  def prepare_variables(variables_param)
+    case variables_param
+    when String
+      if variables_param.present?
+        JSON.parse(variables_param) || {}
+      else
+        {}
+      end
+    when Hash
+      variables_param
+    when ActionController::Parameters
+      variables_param.to_unsafe_hash # GraphQL-Ruby will validate name and type of incoming variables.
+    when nil
+      {}
+    else
+      raise ArgumentError, "Unexpected parameter: #{variables_param}"
+    end
+  end
+
+  def handle_error_in_development(e)
+    logger.error e.message
+    logger.error e.backtrace.join("\n")
+
+    render json: { errors: [{ message: e.message, backtrace: e.backtrace }], data: {} }, status: 500
+  end
+end

--- a/api/app/controllers/graphql_controller.rb
+++ b/api/app/controllers/graphql_controller.rb
@@ -10,7 +10,7 @@ class GraphqlController < ApplicationController
     operation_name = params[:operationName]
     context = {
       # Query context goes here, for example:
-      # current_user: current_user,
+      current_user: current_api_v1_user
     }
     result = ApiSchema.execute(query, variables: variables, context: context, operation_name: operation_name)
     render json: result

--- a/api/app/graphql/api_schema.rb
+++ b/api/app/graphql/api_schema.rb
@@ -1,0 +1,37 @@
+class ApiSchema < GraphQL::Schema
+  mutation(Types::MutationType)
+  query(Types::QueryType)
+
+  # For batch-loading (see https://graphql-ruby.org/dataloader/overview.html)
+  use GraphQL::Dataloader
+
+  # GraphQL-Ruby calls this when something goes wrong while running a query:
+  def self.type_error(err, context)
+    # if err.is_a?(GraphQL::InvalidNullError)
+    #   # report to your bug tracker here
+    #   return nil
+    # end
+    super
+  end
+
+  # Union and Interface Resolution
+  def self.resolve_type(abstract_type, obj, ctx)
+    # TODO: Implement this method
+    # to return the correct GraphQL object type for `obj`
+    raise(GraphQL::RequiredImplementationMissingError)
+  end
+
+  # Relay-style Object Identification:
+
+  # Return a string UUID for `object`
+  def self.id_from_object(object, type_definition, query_ctx)
+    # For example, use Rails' GlobalID library (https://github.com/rails/globalid):
+    object.to_gid_param
+  end
+
+  # Given a string UUID, find the object
+  def self.object_from_id(global_id, query_ctx)
+    # For example, use Rails' GlobalID library (https://github.com/rails/globalid):
+    GlobalID.find(global_id)
+  end
+end

--- a/api/app/graphql/mutations/base_mutation.rb
+++ b/api/app/graphql/mutations/base_mutation.rb
@@ -1,0 +1,8 @@
+module Mutations
+  class BaseMutation < GraphQL::Schema::RelayClassicMutation
+    argument_class Types::BaseArgument
+    field_class Types::BaseField
+    input_object_class Types::BaseInputObject
+    object_class Types::BaseObject
+  end
+end

--- a/api/app/graphql/types/auth_query.rb
+++ b/api/app/graphql/types/auth_query.rb
@@ -1,0 +1,14 @@
+module Types
+  class AuthQuery < Types::BaseObject
+    def authorized?(*_args)
+      raise GraphQL::ExecutionError.new(
+        'permission denied',
+        extensions: {
+          code: 'AUTHENTICATION_ERROR'
+        }
+      ) unless context[:current_user]
+
+      true
+    end
+  end
+end 

--- a/api/app/graphql/types/base_argument.rb
+++ b/api/app/graphql/types/base_argument.rb
@@ -1,0 +1,4 @@
+module Types
+  class BaseArgument < GraphQL::Schema::Argument
+  end
+end

--- a/api/app/graphql/types/base_connection.rb
+++ b/api/app/graphql/types/base_connection.rb
@@ -1,0 +1,6 @@
+module Types
+  class BaseConnection < Types::BaseObject
+    # add `nodes` and `pageInfo` fields, as well as `edge_type(...)` and `node_nullable(...)` overrides
+    include GraphQL::Types::Relay::ConnectionBehaviors
+  end
+end

--- a/api/app/graphql/types/base_edge.rb
+++ b/api/app/graphql/types/base_edge.rb
@@ -1,0 +1,6 @@
+module Types
+  class BaseEdge < Types::BaseObject
+    # add `node` and `cursor` fields, as well as `node_type(...)` override
+    include GraphQL::Types::Relay::EdgeBehaviors
+  end
+end

--- a/api/app/graphql/types/base_enum.rb
+++ b/api/app/graphql/types/base_enum.rb
@@ -1,0 +1,4 @@
+module Types
+  class BaseEnum < GraphQL::Schema::Enum
+  end
+end

--- a/api/app/graphql/types/base_field.rb
+++ b/api/app/graphql/types/base_field.rb
@@ -1,0 +1,5 @@
+module Types
+  class BaseField < GraphQL::Schema::Field
+    argument_class Types::BaseArgument
+  end
+end

--- a/api/app/graphql/types/base_input_object.rb
+++ b/api/app/graphql/types/base_input_object.rb
@@ -1,0 +1,5 @@
+module Types
+  class BaseInputObject < GraphQL::Schema::InputObject
+    argument_class Types::BaseArgument
+  end
+end

--- a/api/app/graphql/types/base_interface.rb
+++ b/api/app/graphql/types/base_interface.rb
@@ -1,0 +1,9 @@
+module Types
+  module BaseInterface
+    include GraphQL::Schema::Interface
+    edge_type_class(Types::BaseEdge)
+    connection_type_class(Types::BaseConnection)
+
+    field_class Types::BaseField
+  end
+end

--- a/api/app/graphql/types/base_object.rb
+++ b/api/app/graphql/types/base_object.rb
@@ -1,0 +1,7 @@
+module Types
+  class BaseObject < GraphQL::Schema::Object
+    edge_type_class(Types::BaseEdge)
+    connection_type_class(Types::BaseConnection)
+    field_class Types::BaseField
+  end
+end

--- a/api/app/graphql/types/base_scalar.rb
+++ b/api/app/graphql/types/base_scalar.rb
@@ -1,0 +1,4 @@
+module Types
+  class BaseScalar < GraphQL::Schema::Scalar
+  end
+end

--- a/api/app/graphql/types/base_union.rb
+++ b/api/app/graphql/types/base_union.rb
@@ -1,0 +1,6 @@
+module Types
+  class BaseUnion < GraphQL::Schema::Union
+    edge_type_class(Types::BaseEdge)
+    connection_type_class(Types::BaseConnection)
+  end
+end

--- a/api/app/graphql/types/mutation_type.rb
+++ b/api/app/graphql/types/mutation_type.rb
@@ -1,0 +1,10 @@
+module Types
+  class MutationType < Types::BaseObject
+    # TODO: remove me
+    field :test_field, String, null: false,
+      description: "An example field added by the generator"
+    def test_field
+      "Hello World"
+    end
+  end
+end

--- a/api/app/graphql/types/node_type.rb
+++ b/api/app/graphql/types/node_type.rb
@@ -1,0 +1,7 @@
+module Types
+  module NodeType
+    include Types::BaseInterface
+    # Add the `id` field
+    include GraphQL::Types::Relay::NodeBehaviors
+  end
+end

--- a/api/app/graphql/types/query_type.rb
+++ b/api/app/graphql/types/query_type.rb
@@ -1,0 +1,17 @@
+module Types
+  class QueryType < Types::BaseObject
+    # Add `node(id: ID!) and `nodes(ids: [ID!]!)`
+    include GraphQL::Types::Relay::HasNodeField
+    include GraphQL::Types::Relay::HasNodesField
+
+    # Add root-level fields here.
+    # They will be entry points for queries on your schema.
+
+    # TODO: remove me
+    field :test_field, String, null: false,
+      description: "An example field added by the generator"
+    def test_field
+      "Hello World!"
+    end
+  end
+end

--- a/api/app/graphql/types/query_type.rb
+++ b/api/app/graphql/types/query_type.rb
@@ -13,5 +13,10 @@ module Types
     def test_field
       "Hello World!"
     end
+
+    field :current_user, Types::UserType, null: true
+    def current_user
+      context[:current_user]
+    end
   end
 end

--- a/api/app/graphql/types/user_type.rb
+++ b/api/app/graphql/types/user_type.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Types
-  class UserType < Types::BaseObject
+  class UserType < Types::AuthQuery
     field :id, ID, null: false
     field :provider, String, null: false
     field :uid, String, null: false

--- a/api/app/graphql/types/user_type.rb
+++ b/api/app/graphql/types/user_type.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Types
+  class UserType < Types::BaseObject
+    field :id, ID, null: false
+    field :provider, String, null: false
+    field :uid, String, null: false
+    field :encrypted_password, String, null: false
+    field :reset_password_token, String
+    field :reset_password_sent_at, GraphQL::Types::ISO8601DateTime
+    field :allow_password_change, Boolean
+    field :remember_created_at, GraphQL::Types::ISO8601DateTime
+    field :confirmation_token, String
+    field :confirmed_at, GraphQL::Types::ISO8601DateTime
+    field :confirmation_sent_at, GraphQL::Types::ISO8601DateTime
+    field :unconfirmed_email, String
+    field :name, String
+    field :nickname, String
+    field :image, String
+    field :email, String
+    field :tokens, String
+    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+  end
+end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -38,6 +38,7 @@
 #                  rails_direct_uploads POST   /rails/active_storage/direct_uploads(.:format)                                           active_storage/direct_uploads#create
 
 Rails.application.routes.draw do
+  post "/graphql", to: "graphql#execute"
   namespace :api do
     namespace :v1 do
 


### PR DESCRIPTION
# Graphqlの初期設定
## 必要なgemのインストール
```ruby
gem 'graphql' 
```

## graphql設定
```
$ docker-compose run api bundle exec rails g graphql:install
```

## 認証用抽象クエリクラス
認証情報を含んだクエリを作成する場合は以下のclassを継承して作成する
`api/app/graphql/types/auth_query.rb`
```ruby
module Types
  class AuthQuery < Types::BaseObject
    def authorized?(*_args)
      raise GraphQL::ExecutionError.new(
        'permission denied',
        extensions: {
          code: 'AUTHENTICATION_ERROR'
        }
      ) unless context[:current_user]

      true
    end
  end
end  
```

## Userタイプ作成
```bash
$ docker-compose run api bundle exec rails g graphql:object User
```

## graphqlでcurrent_userを取得できるように
`graphql_controller.rb`のcontextにユーザー情報を格納する
```ruby
context = {
      # Query context goes here, for example:
      # current_user: current_user,
      current_user: current_api_v1_user
    }
```

`api/app/graphql/types/query_type.rb`
```ruby
field :current_user, Types::UserType, null: true
def current_user
  context[:current_user]
end
```